### PR TITLE
[REFACTOR] HealthChecker 인터페이스 도입으로 헬스체크 클래스 전략화

### DIFF
--- a/src/main/java/springbook/chatbotserver/healcheck/controller/HealthCheckController.java
+++ b/src/main/java/springbook/chatbotserver/healcheck/controller/HealthCheckController.java
@@ -1,73 +1,55 @@
 package springbook.chatbotserver.healcheck.controller;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import springbook.chatbotserver.healcheck.model.HealthCheckResponse;
 import springbook.chatbotserver.healcheck.model.HealthStatus;
-import springbook.chatbotserver.healcheck.service.MariaHealthChecker;
-import springbook.chatbotserver.healcheck.service.MongoHealthChecker;
-import springbook.chatbotserver.healcheck.service.RasaHealthChecker;
-import springbook.chatbotserver.healcheck.service.ServerHealthChecker;
+import springbook.chatbotserver.healcheck.service.HealthChecker;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/v1/api/health")
-@Tag(name = "헬스체크", description = "Spring 서버, MongoDB, Rasa 서버 등 주요 구성 요소의 가용성을 확인하여 서비스 상태를 점검하는 API입니다.")
+@Tag(name = "헬스체크", description = "Spring 서버, MongoDB, Rasa 서버, MariaDB 등 주요 구성 요소의 가용성을 확인하여 서비스 상태를 점검하는 API입니다.")
 public class HealthCheckController {
+  private final List<HealthChecker> healthCheckers;
 
-  private final ServerHealthChecker serverHealthChecker;
-  private final MongoHealthChecker mongoHealthChecker;
-  private final RasaHealthChecker rasaHealthChecker;
-  private final MariaHealthChecker mariaHealthChecker;
-
-  public HealthCheckController(ServerHealthChecker serverHealthChecker,
-      MongoHealthChecker mongoHealthChecker,
-      RasaHealthChecker rasaHealthChecker,
-      MariaHealthChecker mariaHealthChecker) {
-
-    this.serverHealthChecker = serverHealthChecker;
-    this.mongoHealthChecker = mongoHealthChecker;
-    this.rasaHealthChecker = rasaHealthChecker;
-    this.mariaHealthChecker = mariaHealthChecker;
+  @GetMapping("/all")
+  @Operation(summary = "전체 헬스체크", description = "서비스의 가용성을 확인합니다. 모든 구성 요소의 상태를 반환합니다.")
+  public ResponseEntity<Map<String, HealthCheckResponse>> checkAll() {
+    Map<String, HealthCheckResponse> result = new LinkedHashMap<>();
+    for (HealthChecker healthChecker : healthCheckers) {
+      HealthCheckResponse response = healthChecker.checkHealth();
+      result.put(healthChecker.target(), response);
+    }
+    return ResponseEntity.ok(result);
   }
 
-  @Operation(summary = "서버", description = "서버가 정상적으로 작동하는지 확인합니다.")
-  @GetMapping("/server")
-  public ResponseEntity<Object> healthCheck() {
-    HealthCheckResponse response = serverHealthChecker.checkHealth();
-    return ResponseEntity.ok(response);
-
+  @GetMapping("/{target}")
+  @Operation(summary = "단일 헬스체크", description = "서비스의 가용성을 확인합니다. 각 구성 요소의 상태를 반환합니다.(ex: Spring, Mongodb, Rasa, Mariadb 등)")
+  public ResponseEntity<HealthCheckResponse> checkTarget(@PathVariable String target) {
+    return healthCheckers.stream()
+        .filter(c -> c.target().equalsIgnoreCase(target))
+        .findFirst()
+        .map(c -> {
+          HealthCheckResponse res = c.checkHealth();
+          HttpStatus status = res.status() == HealthStatus.UP ? HttpStatus.OK : HttpStatus.INTERNAL_SERVER_ERROR;
+          return ResponseEntity.status(status).body(res);
+        })
+        .orElse(ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(new HealthCheckResponse(HealthStatus.DOWN)));
   }
 
-  @Operation(summary = "MongoDB", description = "MongoDB가 정상적으로 작동하는지 확인합니다.")
-  @GetMapping("/mongodb")
-  public ResponseEntity<Object> healthCheckMongoDB() {
-    HealthCheckResponse response = mongoHealthChecker.checkHealth();
-    return ResponseEntity.status(
-            response.status() == HealthStatus.UP ? HttpStatus.OK : HttpStatus.INTERNAL_SERVER_ERROR)
-        .body(response);
-  }
-
-  @Operation(summary = "rasa", description = "rasa가 정상적으로 작동하는지 확인합니다.")
-  @GetMapping("/rasa")
-  public ResponseEntity<Object> healthCheckRasa() {
-    HealthCheckResponse response = rasaHealthChecker.checkHealth();
-    return ResponseEntity.status(
-            response.status() == HealthStatus.UP ? HttpStatus.OK : HttpStatus.INTERNAL_SERVER_ERROR)
-        .body(response);
-  }
-
-  @Operation(summary = "MariaDB", description = "MariaDB가 정상적으로 작동하는지 확인합니다.")
-  @GetMapping("/mariadb")
-  public ResponseEntity<Object> healthCheckMariaDB() {
-    HealthCheckResponse response = mariaHealthChecker.checkHealth();
-    return ResponseEntity.status(
-            response.status() == HealthStatus.UP ? HttpStatus.OK : HttpStatus.INTERNAL_SERVER_ERROR)
-        .body(response);
-  }
 }

--- a/src/main/java/springbook/chatbotserver/healcheck/model/HealthCheckResponse.java
+++ b/src/main/java/springbook/chatbotserver/healcheck/model/HealthCheckResponse.java
@@ -1,4 +1,8 @@
 package springbook.chatbotserver.healcheck.model;
 
+/**
+ * 서버의 헬스 체크 응답을 나타내는 DTO 클래스입니다.
+ * @param status
+ */
 public record HealthCheckResponse(HealthStatus status) {
 }

--- a/src/main/java/springbook/chatbotserver/healcheck/model/HealthStatus.java
+++ b/src/main/java/springbook/chatbotserver/healcheck/model/HealthStatus.java
@@ -1,5 +1,9 @@
 package springbook.chatbotserver.healcheck.model;
 
+/**
+ * 서버의 건강 상태를 나타내는 열거형입니다.
+ * UP은 서버가 정상 작동 중임을, DOWN은 서버가 작동하지 않음을 의미합니다.
+ */
 public enum HealthStatus {
-	UP, DOWN
+  UP, DOWN
 }

--- a/src/main/java/springbook/chatbotserver/healcheck/service/HealthChecker.java
+++ b/src/main/java/springbook/chatbotserver/healcheck/service/HealthChecker.java
@@ -1,0 +1,14 @@
+package springbook.chatbotserver.healcheck.service;
+
+import springbook.chatbotserver.healcheck.model.HealthCheckResponse;
+
+/**
+ * HealthChecker 인터페이스는 시스템의 건강 상태를 확인하는 기능을 제공합니다.
+ * 각 구현 클래스는 특정 시스템(예: 데이터베이스, 서버 등)의 건강 상태를 체크하고
+ * 그 결과를 반환합니다.
+ */
+public interface HealthChecker {
+  HealthCheckResponse checkHealth();
+
+  String target();
+}

--- a/src/main/java/springbook/chatbotserver/healcheck/service/MariaHealthChecker.java
+++ b/src/main/java/springbook/chatbotserver/healcheck/service/MariaHealthChecker.java
@@ -7,14 +7,20 @@ import org.springframework.stereotype.Service;
 import springbook.chatbotserver.healcheck.model.HealthCheckResponse;
 import springbook.chatbotserver.healcheck.model.HealthStatus;
 
+/**
+ * MariaHealthChecker는 MariaDB 데이터베이스의 건강 상태를 확인하는 서비스입니다.
+ * 데이터베이스 연결을 통해 상태를 체크하고, 결과를 HealthCheckResponse로 반환합니다.
+ */
 @Service
-public class MariaHealthChecker {
+public class MariaHealthChecker implements HealthChecker {
 
   private final DataSource dataSource;
 
   public MariaHealthChecker(DataSource dataSource) {
     this.dataSource = dataSource;
   }
+
+  @Override
   public HealthCheckResponse checkHealth() {
     try (var connection = dataSource.getConnection()) {
       if (connection.isValid(2)) {
@@ -25,5 +31,10 @@ public class MariaHealthChecker {
     } catch (Exception e) {
       return new HealthCheckResponse(HealthStatus.DOWN);
     }
+  }
+
+  @Override
+  public String target() {
+    return "MariaDB";
   }
 }

--- a/src/main/java/springbook/chatbotserver/healcheck/service/MongoHealthChecker.java
+++ b/src/main/java/springbook/chatbotserver/healcheck/service/MongoHealthChecker.java
@@ -7,21 +7,31 @@ import com.mongodb.client.MongoClient;
 import springbook.chatbotserver.healcheck.model.HealthCheckResponse;
 import springbook.chatbotserver.healcheck.model.HealthStatus;
 
+/**
+ * MongoHealthChecker는 MongoDB 데이터베이스의 건강 상태를 확인하는 서비스입니다.
+ * MongoDB 클라이언트를 사용하여 데이터베이스 연결을 통해 상태를 체크하고, 결과를 HealthCheckResponse로 반환합니다.
+ */
 @Service
-public class MongoHealthChecker {
+public class MongoHealthChecker implements HealthChecker {
 
-	private final MongoClient mongoClient;
+  private final MongoClient mongoClient;
 
-	public MongoHealthChecker(MongoClient mongoClient) {
-		this.mongoClient = mongoClient;
-	}
+  public MongoHealthChecker(MongoClient mongoClient) {
+    this.mongoClient = mongoClient;
+  }
 
-	public  HealthCheckResponse checkHealth() {
-		try {
-			mongoClient.listDatabaseNames().first();
-			return new HealthCheckResponse(HealthStatus.UP);
-		} catch (Exception e) {
-			return new HealthCheckResponse(HealthStatus.DOWN);
-		}
-	}
+  @Override
+  public HealthCheckResponse checkHealth() {
+    try {
+      mongoClient.listDatabaseNames().first();
+      return new HealthCheckResponse(HealthStatus.UP);
+    } catch (Exception e) {
+      return new HealthCheckResponse(HealthStatus.DOWN);
+    }
+  }
+
+  @Override
+  public String target() {
+    return "MongoDB";
+  }
 }

--- a/src/main/java/springbook/chatbotserver/healcheck/service/RasaHealthChecker.java
+++ b/src/main/java/springbook/chatbotserver/healcheck/service/RasaHealthChecker.java
@@ -6,21 +6,32 @@ import org.springframework.web.client.RestTemplate;
 import springbook.chatbotserver.healcheck.model.HealthCheckResponse;
 import springbook.chatbotserver.healcheck.model.HealthStatus;
 
+/**
+ * RasaHealthChecker는 Rasa 서버의 건강 상태를 확인하는 서비스입니다.
+ * Rasa 서버의 버전 정보를 요청하여 상태를 체크하고, 결과를 HealthCheckResponse로 반환합니다.
+ */
 @Service
-public class RasaHealthChecker {
+public class RasaHealthChecker implements HealthChecker {
 
-	private final RestTemplate restTemplate;
+  private final RestTemplate restTemplate;
 
-	public RasaHealthChecker(RestTemplate restTemplate) {
-		this.restTemplate = restTemplate;
-	}
-	public HealthCheckResponse checkHealth() {
-		String url = "http://localhost:5005/version";
-		HealthCheckResponse response = restTemplate.getForObject(url, HealthCheckResponse.class);
+  public RasaHealthChecker(RestTemplate restTemplate) {
+    this.restTemplate = restTemplate;
+  }
 
-		if (response == null) {
-			return new HealthCheckResponse(HealthStatus.DOWN);
-		}
-		return new HealthCheckResponse(HealthStatus.UP);
-	}
+  @Override
+  public HealthCheckResponse checkHealth() {
+    String url = "http://localhost:5005/version";
+    HealthCheckResponse response = restTemplate.getForObject(url, HealthCheckResponse.class);
+
+    if (response == null) {
+      return new HealthCheckResponse(HealthStatus.DOWN);
+    }
+    return new HealthCheckResponse(HealthStatus.UP);
+  }
+
+  @Override
+  public String target() {
+    return "Rasa";
+  }
 }

--- a/src/main/java/springbook/chatbotserver/healcheck/service/ServerHealthChecker.java
+++ b/src/main/java/springbook/chatbotserver/healcheck/service/ServerHealthChecker.java
@@ -5,9 +5,20 @@ import org.springframework.stereotype.Service;
 import springbook.chatbotserver.healcheck.model.HealthCheckResponse;
 import springbook.chatbotserver.healcheck.model.HealthStatus;
 
+/**
+ * ServerHealthChecker는 서버의 건강 상태를 확인하는 서비스입니다.
+ * 서버가 작동 중임을 확인하는 로직을 포함하고 있습니다.
+ */
 @Service
-public class ServerHealthChecker {
-	public HealthCheckResponse checkHealth() {
-		return new HealthCheckResponse(HealthStatus.UP);
-	}
+public class ServerHealthChecker implements HealthChecker {
+
+  @Override
+  public HealthCheckResponse checkHealth() {
+    return new HealthCheckResponse(HealthStatus.UP);
+  }
+
+  @Override
+  public String target() {
+    return "Server";
+  }
 }


### PR DESCRIPTION
각 구성 요소의 가용성을 개별적으로 요청하는 방식은 비효율적이라 판단하였으며, 한 번의 요청으로 모든 구성 요소의 서비스 상태를 일괄 점검할 수 있는 구조를 설계하고자 하였다. 또한 구성 요소가 추가될 때마다 클래스 계층에 메서드를 반복적으로 추가하는 방식은 유지보수성이 떨어진다 판단하였고 전략 패턴을 도입하여 각 구성 요소의 헬스 체크 로직을 독립된 전략 객체로 캡슐화 하였다.